### PR TITLE
[REMOTE-SHUFFLE-52] Update shuffle write to not encode/decode parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-	    <scala.version>2.12.10</scala.version>
-	    <scala.binary.version>2.12</scala.binary.version>
+        <scala.version>2.12.10</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -214,8 +214,9 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-core_2.12</artifactId>
+                <artifactId>spark-core_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -231,7 +232,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-core_2.12</artifactId>
+                <artifactId>spark-core_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
                 <classifier>tests</classifier>
                 <type>test-jar</type>

--- a/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/DaosParallelReaderAsync.java
+++ b/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/DaosParallelReaderAsync.java
@@ -114,8 +114,7 @@ public class DaosParallelReaderAsync extends DaosReaderAsync {
   }
 
   private void releaseDescSet() {
-    descSet.forEach(desc -> desc.release());
-    descSet.clear();
+    descSet.forEach(desc -> desc.discard());
   }
 
   @Override

--- a/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/DaosReaderAsync.java
+++ b/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/DaosReaderAsync.java
@@ -204,7 +204,7 @@ public class DaosReaderAsync extends DaosReaderBase {
       e = new IllegalStateException(sb.toString());
     }
     readyList.forEach(desc -> desc.release());
-    runningDescSet.forEach(desc -> desc.release());
+    runningDescSet.forEach(desc -> desc.discard()); // to be released when poll
     if (currentDesc != null) {
       currentDesc.release();
       currentDesc = null;

--- a/shuffle-daos/src/main/scala/org/apache/spark/shuffle/daos/package.scala
+++ b/shuffle-daos/src/main/scala/org/apache/spark/shuffle/daos/package.scala
@@ -32,27 +32,27 @@ package object daos {
 
   val SHUFFLE_DAOS_POOL_UUID =
     ConfigBuilder("spark.shuffle.daos.pool.uuid")
-      .version("3.0.0")
+      .version("3.1.1")
       .stringConf
       .createWithDefault(null)
 
   val SHUFFLE_DAOS_CONTAINER_UUID =
     ConfigBuilder("spark.shuffle.daos.container.uuid")
-      .version("3.0.0")
+      .version("3.1.1")
       .stringConf
       .createWithDefault(null)
 
   val SHUFFLE_DAOS_REMOVE_SHUFFLE_DATA =
     ConfigBuilder("spark.shuffle.remove.shuffle.data")
       .doc("remove shuffle data from DAOS after shuffle completed. Default is true")
-      .version("3.0.0")
+      .version("3.1.1")
       .booleanConf
       .createWithDefault(true)
 
   val SHUFFLE_DAOS_WRITE_BUFFER_INITIAL_SIZE =
     ConfigBuilder("spark.shuffle.daos.write.buffer.initial")
       .doc("initial size of total in-memory buffer for each map output, in MiB")
-      .version("3.0.0")
+      .version("3.1.1")
       .bytesConf(ByteUnit.MiB)
       .checkValue(v => v > 0,
         s"The initial total buffer size must be bigger than 0.")
@@ -62,7 +62,7 @@ package object daos {
     ConfigBuilder("spark.shuffle.daos.write.buffer.percentage")
       .doc("percentage of spark.shuffle.daos.buffer. Force write some buffer data out when size is bigger than " +
         "spark.shuffle.daos.buffer * (this percentage)")
-      .version("3.0.0")
+      .version("3.1.1")
       .doubleConf
       .checkValue(v => v >= 0.5 && v <= 0.9,
         s"The percentage must be no less than 0.5 and less than or equal to 0.9")
@@ -72,7 +72,7 @@ package object daos {
     ConfigBuilder("spark.shuffle.daos.write.minimum")
       .doc("minimum size when write to DAOS, in KiB. A warning will be generated when size is less than this value" +
         " and spark.shuffle.daos.write.warn.small is set to true")
-      .version("3.0.0")
+      .version("3.1.1")
       .bytesConf(ByteUnit.KiB)
       .checkValue(v => v > 0,
         s"The DAOS write minimum size must be positive")
@@ -82,14 +82,14 @@ package object daos {
     ConfigBuilder("spark.shuffle.daos.write.warn.small")
       .doc("log warning message when the size of written data is smaller than spark.shuffle.daos.write.minimum." +
         " Default is false")
-      .version("3.0.0")
+      .version("3.1.1")
       .booleanConf
       .createWithDefault(false)
 
   val SHUFFLE_DAOS_WRITE_SINGLE_BUFFER_SIZE =
     ConfigBuilder("spark.shuffle.daos.write.buffer.single")
       .doc("size of single buffer for holding data to be written to DAOS")
-      .version("3.0.0")
+      .version("3.1.1")
       .bytesConf(ByteUnit.MiB)
       .checkValue(v => v >= 1,
         s"The single DAOS write buffer must be at least 1m")
@@ -98,7 +98,7 @@ package object daos {
   val SHUFFLE_DAOS_WRITE_FLUSH_RECORDS =
     ConfigBuilder("spark.shuffle.daos.write.flush.records")
       .doc("per how many number of records to flush data in buffer to DAOS")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v >= 100,
       s"number of records to flush should be more than 100")
@@ -107,7 +107,7 @@ package object daos {
   val SHUFFLE_DAOS_READ_MINIMUM_SIZE =
     ConfigBuilder("spark.shuffle.daos.read.minimum")
       .doc("minimum size when read from DAOS, in KiB. ")
-      .version("3.0.0")
+      .version("3.1.1")
       .bytesConf(ByteUnit.KiB)
       .checkValue(v => v > 0,
         s"The DAOS read minimum size must be positive")
@@ -116,7 +116,7 @@ package object daos {
   val SHUFFLE_DAOS_READ_MAX_BYTES_IN_FLIGHT =
     ConfigBuilder("spark.shuffle.daos.read.maxbytes.inflight")
       .doc("maximum size of requested data when read from DAOS, in KiB. ")
-      .version("3.0.0")
+      .version("3.1.1")
       .bytesConf(ByteUnit.KiB)
       .checkValue(v => v > 0,
         s"The DAOS read max bytes in flight must be positive")
@@ -125,7 +125,7 @@ package object daos {
   val SHUFFLE_DAOS_WRITE_MAX_BYTES_IN_FLIGHT =
     ConfigBuilder("spark.shuffle.daos.write.maxbytes.inflight")
       .doc("maximum size of requested data when write to DAOS, in KiB. ")
-      .version("3.0.0")
+      .version("3.1.1")
       .bytesConf(ByteUnit.KiB)
       .checkValue(v => v > 0,
         s"The DAOS write max bytes in flight must be positive")
@@ -134,7 +134,7 @@ package object daos {
   val SHUFFLE_DAOS_IO_ASYNC =
     ConfigBuilder("spark.shuffle.daos.io.async")
       .doc("perform shuffle IO asynchronously. Default is true")
-      .version("3.0.0")
+      .version("3.1.1")
       .booleanConf
       .createWithDefault(true)
 
@@ -142,7 +142,7 @@ package object daos {
     ConfigBuilder("spark.shuffle.daos.read.threads")
       .doc("number of threads for each executor to read shuffle data concurrently. -1 means use number of executor " +
         "cores. sync IO only.")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .createWithDefault(1)
 
@@ -150,14 +150,14 @@ package object daos {
     ConfigBuilder("spark.shuffle.daos.write.threads")
       .doc("number of threads for each executor to write shuffle data concurrently. -1 means use number of executor " +
         "cores. sync IO only.")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .createWithDefault(1)
 
   val SHUFFLE_DAOS_ASYNC_WRITE_BATCH_SIZE =
     ConfigBuilder("spark.shuffle.daos.async.write.batch")
       .doc("number of async write before flush")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v > 0,
         s"async write batch size must be positive")
@@ -166,7 +166,7 @@ package object daos {
   val SHUFFLE_DAOS_READ_BATCH_SIZE =
     ConfigBuilder("spark.shuffle.daos.read.batch")
       .doc("number of read tasks to submit at most at each time. sync IO only.")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v > 0,
         s"read batch size must be positive")
@@ -175,16 +175,25 @@ package object daos {
   val SHUFFLE_DAOS_WRITE_SUBMITTED_LIMIT =
     ConfigBuilder("spark.shuffle.daos.write.submitted.limit")
       .doc("limit of number of write tasks to submit. sync IO only.")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v > 0,
         s"limit of submitted task must be positive")
       .createWithDefault(20)
 
+  val SHUFFLE_DAOS_WRITE_ASYNC_DESC_CACHES =
+    ConfigBuilder("spark.shuffle.daos.write.async.desc.caches")
+      .doc("number of cached I/O description objects for async write.")
+      .version("3.1.1")
+      .intConf
+      .checkValue(v => v >= 0,
+        s"number of cached I/O description objects must be no less than 0")
+      .createWithDefault(20)
+
   val SHUFFLE_DAOS_READ_WAIT_MS =
     ConfigBuilder("spark.shuffle.daos.read.wait.ms")
       .doc("number of milliseconds to wait data being read before timed out")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v > 0,
         s"wait data time must be positive")
@@ -193,7 +202,7 @@ package object daos {
   val SHUFFLE_DAOS_WRITE_WAIT_MS =
     ConfigBuilder("spark.shuffle.daos.write.wait.ms")
       .doc("number of milliseconds to wait data being written before timed out")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v > 0,
         s"wait data time must be positive")
@@ -203,7 +212,7 @@ package object daos {
     ConfigBuilder("spark.shuffle.daos.write.wait.timeout.times")
       .doc("number of wait timeout (spark.shuffle.daos.write.waitdata.ms) after which shuffle write task fails." +
         "sync IO only.")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v > 0,
         s"wait data timeout times must be positive")
@@ -212,21 +221,21 @@ package object daos {
   val SHUFFLE_DAOS_READ_FROM_OTHER_THREAD =
     ConfigBuilder("spark.shuffle.daos.read.from.other.threads")
       .doc("whether read shuffled data from other threads or not. true by default. sync IO only.")
-      .version("3.0.0")
+      .version("3.1.1")
       .booleanConf
       .createWithDefault(true)
 
   val SHUFFLE_DAOS_WRITE_IN_OTHER_THREAD =
     ConfigBuilder("spark.shuffle.daos.write.in.other.threads")
       .doc("whether write shuffled data in other threads or not. true by default. sync IO only.")
-      .version("3.0.0")
+      .version("3.1.1")
       .booleanConf
       .createWithDefault(true)
 
   val SHUFFLE_DAOS_WRITE_PARTITION_MOVE_INTERVAL =
     ConfigBuilder("spark.shuffle.daos.write.partition.move.interval")
       .doc("move partition at every this interval (number of records). 1000 records by default.")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v >= 10, "partition move interval should be at least 10.")
       .createWithDefault(1000)
@@ -236,7 +245,7 @@ package object daos {
       .doc("check total size of partitions and write some partitions at every this interval (number of records)." +
         " This value should be no less than spark.shuffle.daos.write.partition.move.interval." +
         " 10000 records by default.")
-      .version("3.0.0")
+      .version("3.1.1")
       .intConf
       .checkValue(v => v > 0, "total interval should be bigger than 0.")
       .createWithDefault(32)
@@ -248,7 +257,7 @@ package object daos {
         "spark.shuffle.daos.spill.grant.pct. The shuffle manager will also spill if there are equal or more than two" +
         " consecutive lowly granted memory (granted memory < requested memory). When it's false, the shuffle manager " +
         "will spill once there is lowly granted memory.")
-      .version("3.0.0")
+      .version("3.1.1")
       .booleanConf
       .createWithDefault(true)
 
@@ -258,7 +267,7 @@ package object daos {
         " cores\"). It takes effect only if spark.shuffle.daos.spill.first is true. When granted memory from" +
         " TaskMemoryManager is less than task heap memory * this percentage, spill data to DAOS. Default is 0.1. It " +
         "should be less than 0.5.")
-      .version("3.0.0")
+      .version("3.1.1")
       .doubleConf
       .checkValue(v => v > 0 & v < 0.5, "spill grant percentage should be greater than 0 and no more" +
         " than 0.5 .")

--- a/shuffle-daos/src/test/java/org/apache/spark/shuffle/daos/DaosWriterAsyncTest.java
+++ b/shuffle-daos/src/test/java/org/apache/spark/shuffle/daos/DaosWriterAsyncTest.java
@@ -1,0 +1,128 @@
+package org.apache.spark.shuffle.daos;
+
+import io.daos.obj.IODescUpdAsync;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DaosWriterAsyncTest {
+
+  @Test
+  public void testDescCacheNotFull() {
+    DaosWriterAsync.AsyncDescCache cache = new DaosWriterAsync.AsyncDescCache(10) {
+      public IODescUpdAsync newObject() {
+        IODescUpdAsync desc = Mockito.mock(IODescUpdAsync.class);
+        Mockito.when(desc.isReusable()).thenReturn(true);
+        return desc;
+      }
+    };
+    List<IODescUpdAsync> list = new ArrayList<>();
+    try {
+      for (int i = 0; i < 5; i++) {
+        IODescUpdAsync desc = cache.get();
+        Assert.assertTrue(desc.isReusable());
+        Assert.assertEquals(i + 1, cache.getIdx());
+        list.add(desc);
+      }
+      // test reuse
+      IODescUpdAsync desc = list.remove(0);
+      cache.put(desc);
+      Assert.assertEquals(4, cache.getIdx());
+      Assert.assertEquals(desc, cache.get());
+      cache.put(desc);
+      for (IODescUpdAsync d : list) {
+        cache.put(d);
+      }
+      Assert.assertEquals(0, cache.getIdx());
+    } finally {
+      cache.release();
+      list.forEach(d -> d.release());
+    }
+  }
+
+  @Test
+  public void testDescCacheFull() {
+    DaosWriterAsync.AsyncDescCache cache = new DaosWriterAsync.AsyncDescCache(10) {
+      public IODescUpdAsync newObject() {
+        IODescUpdAsync desc = Mockito.mock(IODescUpdAsync.class);
+        Mockito.when(desc.isReusable()).thenReturn(true);
+        return desc;
+      }
+    };
+    List<IODescUpdAsync> list = new ArrayList<>();
+    Exception ee = null;
+    try {
+      for (int i = 0; i < 11; i++) {
+        IODescUpdAsync desc = cache.get();
+        Assert.assertTrue(desc.isReusable());
+        Assert.assertEquals(i + 1, cache.getIdx());
+        list.add(desc);
+      }
+    } catch (IllegalStateException e) {
+      ee = e;
+    }
+    Assert.assertTrue(ee instanceof IllegalStateException);
+    Assert.assertTrue(ee.getMessage().contains("cache is full"));
+    Assert.assertTrue(cache.isFull());
+
+    try {
+      // test reuse
+      IODescUpdAsync desc = list.remove(0);
+      cache.put(desc);
+      Assert.assertEquals(9, cache.getIdx());
+      Assert.assertEquals(desc, cache.get());
+      cache.put(desc);
+      for (IODescUpdAsync d : list) {
+        cache.put(d);
+      }
+      Assert.assertEquals(0, cache.getIdx());
+      desc = cache.get();
+      Assert.assertEquals(1, cache.getIdx());
+      cache.put(desc);
+      Assert.assertEquals(0, cache.getIdx());
+    } finally {
+      cache.release();
+      list.forEach(d -> d.release());
+    }
+  }
+
+  @Test
+  public void testDescCachePut() {
+    DaosWriterAsync.AsyncDescCache cache = new DaosWriterAsync.AsyncDescCache(10) {
+      public IODescUpdAsync newObject() {
+        IODescUpdAsync desc = Mockito.mock(IODescUpdAsync.class);
+        Mockito.when(desc.isReusable()).thenReturn(true);
+        return desc;
+      }
+    };
+    List<IODescUpdAsync> list = new ArrayList<>();
+
+    for (int i = 0; i < 10; i++) {
+      IODescUpdAsync desc = cache.get();
+      Assert.assertTrue(desc.isReusable());
+      Assert.assertEquals(i + 1, cache.getIdx());
+      list.add(desc);
+    }
+    Assert.assertTrue(cache.isFull());
+
+    IODescUpdAsync desc = null;
+    while (!list.isEmpty()) {
+      desc = list.remove(0);
+      cache.put(desc);
+    }
+    Exception ee = null;
+    try {
+      cache.put(desc);
+    } catch (Exception e) {
+      ee = e;
+    } finally {
+      cache.release();
+      list.forEach(d -> d.release());
+    }
+    Assert.assertTrue(ee instanceof IllegalStateException);
+    Assert.assertTrue(ee.getMessage().contains("more than actual"));
+  }
+}

--- a/shuffle-hadoop/pom.xml
+++ b/shuffle-hadoop/pom.xml
@@ -47,11 +47,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <version>2.7.4</version>
-    </dependency>
-    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>

## What changes were proposed in this pull request?

replace IOSimpleDDAsync with IODescUpdAsync which writes one akey at a time without parameter encode/decode. IODescUpdAsync also supports caching to reduce GC pressue.


## How was this patch tested?

Tested in wolf with workload repartition. The shuffle write perf improved about 10%.
