### PR TITLE
[REMOTE-SHUFFLE-70] use DAOS object class hint instead of DAOS object class

### DIFF
--- a/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/DaosWriter.java
+++ b/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/DaosWriter.java
@@ -240,9 +240,6 @@ public interface DaosWriter {
     private long submittedSize;
     private int nbrOfSubmitted;
 
-    // debug
-//    private List<Integer> sizeList = new ArrayList<>();
-
     private DaosObject object;
 
     private static final Logger LOG = LoggerFactory.getLogger(NativeBuffer.class);
@@ -410,8 +407,6 @@ public interface DaosWriter {
         }
         bufSize += buf.readableBytes();
         descList.add(desc);
-        // debug
-//        sizeList.add(buf.readableBytes());
       }
 
       nbrOfSubmitted = nbrOfBuf;
@@ -498,30 +493,6 @@ public interface DaosWriter {
         seq++;
       }
     }
-
-//    public void debugSizes() {
-//      Collections.sort(sizeList);
-//      long total = 0L;
-//      for (Integer integer : sizeList) {
-//        total += integer;
-//      }
-//      float avg = total * 1.0f / sizeList.size();
-//      int min = sizeList.get(0);
-//      int q1 = sizeList.get(sizeList.size()/4);
-//      int q2 = sizeList.get(sizeList.size()/2);
-//      int q3 = sizeList.get(sizeList.size() * 3 /4);
-//      int max = sizeList.get(sizeList.size() -1);
-//      sizeList.clear();
-//      sizeList = null;
-//      LOG.info("BUFSTATISTICS: " +
-//          "AVG: " + avg +
-//          "MIN: " + min +
-//          "Q1: " + q1 +
-//          "Q2: " + q2 +
-//          "Q3: " + q3 +
-//          "MAX: " + max
-//      );
-//    }
   }
 
   /**

--- a/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/DaosWriterAsync.java
+++ b/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/DaosWriterAsync.java
@@ -89,10 +89,6 @@ public class DaosWriterAsync extends DaosWriterBase {
       assert Thread.currentThread().getId() == eq.getThreadId() : "current thread " + Thread.currentThread().getId() +
           "(" + Thread.currentThread().getName() + "), is not expected " + eq.getThreadId() + "(" +
           eq.getThreadName() + ")";
-
-//      if (!descSet.isEmpty()) {
-//        pollOnce(descSet.size(), 1L);
-//      }
       for (IODescUpdAsync desc : descList) {
         DaosEventQueue.Event event = acquireEvent();
         descSet.add(desc);
@@ -123,7 +119,6 @@ public class DaosWriterAsync extends DaosWriterBase {
       }
       List<IODescUpdAsync> descList = buffer.createUpdateDescAsyncs(eq.getEqWrapperHdl(), cache, false);
       flush(buffer, descList);
-//      buffer.debugSizes();
     }
     waitCompletion();
   }

--- a/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/IOManager.java
+++ b/shuffle-daos/src/main/java/org/apache/spark/shuffle/daos/IOManager.java
@@ -64,9 +64,11 @@ public abstract class IOManager {
     String key = getKey(appId, shuffleId);
     DaosObject object = objectMap.get(key);
     if (object == null) {
+      // we use object class hint instead of object class
+      // so set object class to UNKNOWN
       DaosObjectId id = new DaosObjectId(appId, shuffleId);
       id.encode(objClient.getContPtr(), DaosObjectType.DAOS_OT_DKEY_UINT64,
-          DaosObjectClass.valueOf(conf.get(package$.MODULE$.SHUFFLE_DAOS_OBJECT_CLASS())),
+          DaosObjectClass.OC_UNKNOWN,
           DaosObjClassHint.valueOf(conf.get(package$.MODULE$.SHUFFLE_DAOS_OBJECT_HINT())), 0);
       object = objClient.getObject(id);
       log.info("created new object, oid high: " + object.getOid().getHigh() + ", low: " + object.getOid().getLow());

--- a/shuffle-daos/src/main/scala/org/apache/spark/shuffle/daos/package.scala
+++ b/shuffle-daos/src/main/scala/org/apache/spark/shuffle/daos/package.scala
@@ -273,14 +273,6 @@ package object daos {
         " than 0.5 .")
       .createWithDefault(0.1)
 
-  val SHUFFLE_DAOS_OBJECT_CLASS =
-    ConfigBuilder("spark.shuffle.daos.object.class")
-      .doc("class of DAOS object for storing shuffled data. It tells DAOS how object data is stored and replicated. " +
-        "Check io.daos.DaosObjectClass for all available classes.")
-      .version("3.1.1")
-      .stringConf
-      .createWithDefault("OC_UNKNOWN")
-
   val SHUFFLE_DAOS_OBJECT_HINT =
     ConfigBuilder("spark.shuffle.daos.object.hint")
       .doc("hint of DAOS object class. It's about data redundancy and sharding in DAOS. Check " +

--- a/shuffle-daos/src/test/java/org/apache/spark/shuffle/daos/DaosShuffleIOTest.java
+++ b/shuffle-daos/src/test/java/org/apache/spark/shuffle/daos/DaosShuffleIOTest.java
@@ -81,6 +81,7 @@ public class DaosShuffleIOTest {
       DaosObject daosObject = PowerMockito.mock(DaosObject.class);
       DaosObjClient client = PowerMockito.mock(DaosObjClient.class);
       Mockito.when(client.getObject(id)).thenReturn(daosObject);
+      Mockito.when(daosObject.getOid()).thenReturn(id);
 
       AtomicBoolean open = new AtomicBoolean(false);
       Mockito.when(daosObject.isOpen()).then(invocationOnMock ->


### PR DESCRIPTION

## What changes were proposed in this pull request?

removed daos object class config item and hard-coded it to OC_UNKNOWN.


## How was this patch tested?

patch in UT

